### PR TITLE
Fix libp2p listener

### DIFF
--- a/01_Tutorial/04_P2P_Part_1.md
+++ b/01_Tutorial/04_P2P_Part_1.md
@@ -207,7 +207,7 @@ Then, update the `_init` function to include an event handler for when a peer is
       'nodeId': peerInfo.id
     })
 
-+   this.node.libp2p.on('peer:connect', this.handlePeerConnected.bind(this))
++   this.node.libp2p.connectionManager.on('peer:connect', this.handlePeerConnected.bind(this))
 
     this.onready()
   }

--- a/code_examples/01_Tutorial/04_P2P_Part_1/newpieceplease.js
+++ b/code_examples/01_Tutorial/04_P2P_Part_1/newpieceplease.js
@@ -41,7 +41,7 @@ class NewPiecePlease {
             "nodeId": nodeInfo.id
         })
 
-        this.node.libp2p.on("peer:connect", this.handlePeerConnected.bind(this))
+        this.node.libp2p.connectionManager.on("peer:connect", this.handlePeerConnected.bind(this))
         await this.node.pubsub.subscribe(nodeInfo.id, this.handleMessageReceived.bind(this))
 
         // when the OrbitDB docstore has loaded, intercept this method to


### PR DESCRIPTION
`peer:connect` listeners now seem to have to be made on the `libp2p.connectionManager` object.