### PR TITLE
Update 04_P2P_Part_1.md

### DIFF
--- a/01_Tutorial/04_P2P_Part_1.md
+++ b/01_Tutorial/04_P2P_Part_1.md
@@ -150,8 +150,8 @@ Create the `getIpfsPeers` function inside of the `NewPiecePlease` class.
 
 ```diff
 + async getIpfsPeers() {
-+   const peers = await this.node.swarm.peers()
-+   return peers
++   const peerIds = (await this.node.swarm.peers()).map(peer => peer.peer)
++   return peerIds
 + }
 ```
 


### PR DESCRIPTION
`this.node.swarm.peers()` seems to return an array of objects containing both multiaddress and peerId. Since the next section (Chapter 5) relies on `getIpfsPeers` returning an array of peerIds as strings in `connectToCompanions`, we need to get the peerId form the object.